### PR TITLE
Provide compatibility with foliantcontrib.includes 1.0.7.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 1.0.3 (under development)
+
+-   Use flattened file path in `includes` preprocessor call.
+-   Require `includes` preprocessor 1.0.7.
+
 # 1.0.2
 
 -   Fix incorrect `includes` preprocessor call.

--- a/foliant/preprocessors/flatten.py
+++ b/foliant/preprocessors/flatten.py
@@ -47,17 +47,17 @@ class Preprocessor(BasePreprocessor):
 
         self.logger.debug('Resolving includes.')
 
+        flat_src_file_path = self.working_dir / self.options['flat_src_file_name']
+
         flat_src = includes.Preprocessor(
             self.context,
             self.logger,
             {'recursive': False}
-        ).process_includes(flat_src)
+        ).process_includes(flat_src_file_path, flat_src)
 
         for markdown_file in self.working_dir.rglob('*.md'):
             self.logger.debug(f'Removing {markdown_file}')
             markdown_file.unlink()
-
-        flat_src_file_path = self.working_dir / self.options['flat_src_file_name']
 
         with open(flat_src_file_path, 'w', encoding='utf8') as flat_src_file:
             self.logger.debug(f'Saving flat source into {flat_src_file_path}')

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     platforms='any',
     install_requires=[
         'foliant>=1.0.5',
-        'foliantcontrib.includes'
+        'foliantcontrib.includes>=1.0.7'
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Use flattened file path in `process_includes` method call.